### PR TITLE
Add default closure for pre-post configuration

### DIFF
--- a/Source/Imaginary.swift
+++ b/Source/Imaginary.swift
@@ -2,8 +2,16 @@ import UIKit
 import Cache
 
 public struct Imaginary {
-  public static var preConfigure: ((imageView: UIImageView) -> Void)?
-  public static var postConfigure: ((imageView: UIImageView) -> Void)?
+
+  public static var preConfigure: ((imageView: UIImageView) -> Void)? = { imageView in
+    imageView.alpha = 0.0
+  }
+
+  public static var postConfigure: ((imageView: UIImageView) -> Void)? = { imageView in
+    UIView.animateWithDuration(0.3) {
+      imageView.alpha = 1.0
+    }
+  }
 }
 
 public var imageCache: Cache<UIImage> {


### PR DESCRIPTION
This PR adds default fading when loading images from a remote location.
You can still supply your own transformation for when the images are loaded
but this makes for a "fancier" out-of-the-box setup.
