### PR TITLE
Improve user experience when using Imaginary

### DIFF
--- a/Example/ImaginaryDemo/ImaginaryDemo/ViewController.swift
+++ b/Example/ImaginaryDemo/ImaginaryDemo/ViewController.swift
@@ -14,8 +14,7 @@ class ViewController: UITableViewController {
 
     for i in 0..<Constants.imageNumber {
       if let imageURL = NSURL(
-        string: faker.internet.image(width: Constants.imageWidth, height: Constants.imageHeight)
-          + "?type=attachment&id=(\(i))(50)") {
+        string: "https://unsplash.it/600/300/?image=\(i)") {
             array.append(imageURL)
       }
     }

--- a/Example/ImaginaryDemo/ImaginaryDemo/ViewController.swift
+++ b/Example/ImaginaryDemo/ImaginaryDemo/ViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import Fakery
 import Imaginary
 
 class ViewController: UITableViewController {
@@ -11,7 +10,6 @@ class ViewController: UITableViewController {
   }
 
   lazy var imaginaryArray: [NSURL] = { [unowned self] in
-    let faker = Faker()
     var array = [NSURL]()
 
     for i in 0..<Constants.imageNumber {

--- a/Example/ImaginaryDemo/Podfile
+++ b/Example/ImaginaryDemo/Podfile
@@ -5,7 +5,6 @@ inhibit_all_warnings!
 
 
 pod 'Imaginary', path: '../../'
-pod 'Fakery'
 pod 'Cache', git: 'https://github.com/hyperoslo/Cache'
 
 target 'ImaginaryDemo'

--- a/Example/ImaginaryDemo/Podfile.lock
+++ b/Example/ImaginaryDemo/Podfile.lock
@@ -1,21 +1,17 @@
 PODS:
   - Cache (0.1.0)
-  - Fakery (1.1.0):
-    - SwiftyJSON
   - Imaginary (0.1.0):
     - Cache
-  - SwiftyJSON (2.3.2)
 
 DEPENDENCIES:
   - Cache (from `https://github.com/hyperoslo/Cache`)
-  - Fakery
   - Imaginary (from `../../`)
 
 EXTERNAL SOURCES:
   Cache:
     :git: https://github.com/hyperoslo/Cache
   Imaginary:
-    :path: ../../
+    :path: "../../"
 
 CHECKOUT OPTIONS:
   Cache:
@@ -24,10 +20,8 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Cache: 59ea9dbb71dfa1ba68a6efe295e907603b3066da
-  Fakery: 593389814fb7c42fe7f0801e76c8ae55b95505e7
   Imaginary: 5317b8d2dc8ecf20455232226bf8a277abdd37d5
-  SwiftyJSON: 04ccea08915aa0109039157c7974cf0298da292a
 
-PODFILE CHECKSUM: 59255a311bdb21b53b1b9dfeb7eb5bf8d64ddc1f
+PODFILE CHECKSUM: eeff3e5a8f20502e24b1eaa68f2a4c9eeece699d
 
 COCOAPODS: 1.0.0

--- a/Source/Extensions/UIImageView+Imaginary.swift
+++ b/Source/Extensions/UIImageView+Imaginary.swift
@@ -37,7 +37,7 @@ extension UIImageView {
 
         switch result {
         case let .Success(image):
-          weakSelf.image = image
+          Imaginary.transitionClosure(imageView: weakSelf, image: image)
           imageCache.add(key, object: image)
           completion?()
         default:

--- a/Source/Extensions/UIImageView+Imaginary.swift
+++ b/Source/Extensions/UIImageView+Imaginary.swift
@@ -26,7 +26,10 @@ extension UIImageView {
         return
       }
 
-      Imaginary.preConfigure?(imageView: weakSelf)
+      if placeholder == nil {
+        Imaginary.preConfigure?(imageView: weakSelf)
+      }
+
       weakSelf.fetcher = Fetcher(URL: URL)
 
       weakSelf.fetcher?.start { [weak self] result in

--- a/Source/Imaginary.swift
+++ b/Source/Imaginary.swift
@@ -6,6 +6,19 @@ public struct Imaginary {
   public static var preConfigure: ((imageView: UIImageView) -> Void)? = { imageView in
     imageView.layer.opacity = 0.0
   }
+  
+  public static var transitionClosure: ((imageView: UIImageView, image: UIImage) -> Void) = { imageView, newImage in
+    guard let oldImage = imageView.image else {
+      imageView.image = newImage
+      return
+    }
+
+    let animation = CABasicAnimation(keyPath: "contents")
+    animation.duration = 0.25
+    animation.fromValue = oldImage.CGImage
+    animation.toValue = newImage.CGImage
+    imageView.layer.addAnimation(animation, forKey: "transitionAnimation")
+    imageView.image = newImage
   }
 
   public static var postConfigure: ((imageView: UIImageView) -> Void)? = { imageView in

--- a/Source/Imaginary.swift
+++ b/Source/Imaginary.swift
@@ -4,13 +4,16 @@ import Cache
 public struct Imaginary {
 
   public static var preConfigure: ((imageView: UIImageView) -> Void)? = { imageView in
-    imageView.alpha = 0.0
+    imageView.layer.opacity = 0.0
+  }
   }
 
   public static var postConfigure: ((imageView: UIImageView) -> Void)? = { imageView in
-    UIView.animateWithDuration(0.3) {
-      imageView.alpha = 1.0
-    }
+    let animation = CABasicAnimation(keyPath: "opacity")
+    animation.fromValue = imageView.layer.opacity
+    animation.toValue = 1.0
+    imageView.layer.addAnimation(animation, forKey: "fadeAnimation")
+    imageView.layer.opacity = 1.0
   }
 }
 


### PR DESCRIPTION
This PR improves the way that Imaginary works with placeholders and setting the images with animation.

Before we used `UIView.animateWithDuration` which could affect the scrolling experience when using `Imaginary` in a long feed. Now we use `CALayer` based animations which should hopefully fix the issue.

This PR also introduces a transition closure that adds a smooth transition between the placeholder and the newly fetch image.
