### PR TITLE
Improve memory handling

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,0 +1,3 @@
+{
+  "maxReviewers": 2
+}

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,40 @@
+included: # paths to include during linting. `--path` is ignored if present.
+  - Source
+excluded: # paths to ignore during linting. Takes precedence over `included`.
+  - Carthage
+  - Pods
+
+# configurable rules can be customized from this configuration file
+# binary rules can set their severity level
+force_cast: warning # implicitly
+force_try:
+  severity: warning # explicitly
+# rules that have both warning and error levels, can set just the warning level
+# implicitly
+line_length: 200
+# they can set both implicitly with an array
+type_body_length:
+  - 300 # warning
+  - 400 # error
+# or they can set both explicitly
+file_length:
+  warning: 500
+  error: 1200
+# naming rules can set warnings/errors for min_length and max_length
+# additionally they can set excluded names
+type_name:
+  min_length: 3 # only warning
+  max_length: # warning and error
+    warning: 40
+    error: 50
+  excluded: iPhone # excluded via string
+variable_name:
+  min_length: # only min_length
+    error: 2 # only error
+  excluded: # excluded via string array
+    - x
+    - y
+    - id
+    - URL
+    - GlobalAPIKey
+reporter: "xcode" # reporter type (xcode, json, csv, checkstyle)

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,2 @@
-github "hyperoslo/Cache" "5af9d7f80b5c39ec578c54874d5acda248d10831"
+github "krzyzanowskim/CryptoSwift" "0.4.1"
+github "hyperoslo/Cache" "36ef82487589ad6c91cfc66308ff0c799512b9d6"

--- a/Imaginary.xcodeproj/project.pbxproj
+++ b/Imaginary.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 				D5DF758E1C403D8200BF1AB6 /* Headers */,
 				D5DF758F1C403D8200BF1AB6 /* Resources */,
 				D5DF75B31C403FC700BF1AB6 /* Run Script */,
+				BD58C3AF1CF30382003F7141 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -180,6 +181,19 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		BD58C3AF1CF30382003F7141 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+		};
 		D5DF75B31C403FC700BF1AB6 /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/Source/Data/Capsule.swift
+++ b/Source/Data/Capsule.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class Capsule : NSObject {
+class Capsule: NSObject {
 
   static var ObjectKey = 0
   let value: Any

--- a/Source/Data/Fetcher.swift
+++ b/Source/Data/Fetcher.swift
@@ -84,7 +84,7 @@ class Fetcher {
 
   func complete(closure: () -> Void) {
     active = false
-    
+
     dispatch_async(dispatch_get_main_queue()) {
       closure()
     }

--- a/Source/Extensions/UIImageView+Imaginary.swift
+++ b/Source/Extensions/UIImageView+Imaginary.swift
@@ -55,7 +55,7 @@ extension UIImageView {
       return fetcher
     }
     set (fetcher) {
-      var wrapper : Capsule?
+      var wrapper: Capsule?
       if let fetcher = fetcher {
         wrapper = Capsule(value: fetcher)
       }

--- a/Source/Imaginary.swift
+++ b/Source/Imaginary.swift
@@ -6,7 +6,7 @@ public struct Imaginary {
   public static var preConfigure: ((imageView: UIImageView) -> Void)? = { imageView in
     imageView.layer.opacity = 0.0
   }
-  
+
   public static var transitionClosure: ((imageView: UIImageView, image: UIImage) -> Void) = { imageView, newImage in
     guard let oldImage = imageView.image else {
       imageView.image = newImage
@@ -36,9 +36,10 @@ public var imageCache: Cache<UIImage> {
       frontKind: .Memory,
       backKind: .Disk,
       expiry: .Date(NSDate().dateByAddingTimeInterval(60 * 60 * 24 * 3)),
-      maxSize: 0)
+      maxSize: 0,
+      maxObjects: 10)
 
-    static let cache = Cache<UIImage>(name: "Imaginary")
+    static let cache = Cache<UIImage>(name: "Imaginary", config: config)
   }
 
   return Static.cache

--- a/Source/Imaginary.swift
+++ b/Source/Imaginary.swift
@@ -31,6 +31,7 @@ public struct Imaginary {
 }
 
 public var imageCache: Cache<UIImage> {
+
   struct Static {
     static let config = Config(
       frontKind: .Memory,


### PR DESCRIPTION
This PR aims to improve the memory usage of `Imaginary`. Based on the changes in https://github.com/hyperoslo/Cache/pull/41, the memory footprint of `Imaginary` is significantly lower.

This data is from an internal application that as a feed feature with a lot of content, in this particular example it is a feed with 882 items (not all images).x
### Before

<img width="298" alt="screen shot 2016-05-23 at 11 01 49" src="https://cloud.githubusercontent.com/assets/57446/15466082/1abe45c4-20d8-11e6-8f81-d41162fd82f1.PNG">
### After

<img width="300" alt="screen shot 2016-05-23 at 11 04 26" src="https://cloud.githubusercontent.com/assets/57446/15466086/2004189c-20d8-11e6-837f-880f8153189b.PNG">
