### PR TITLE
Feature: image preprocessing

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "krzyzanowskim/CryptoSwift" "0.5.1"
-github "hyperoslo/Cache" "d6f0b013cbe9ede4b5fe5a8b615220abce0327d6"
+github "krzyzanowskim/CryptoSwift" "0.5.2"
+github "hyperoslo/Cache" "4d7029d95a0b0a77ead2f0144b99bf6543452e3d"

--- a/Imaginary.xcodeproj/project.pbxproj
+++ b/Imaginary.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		D54225371D1D7AF100AF0046 /* NSImage+CGImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54225291D1D7ABD00AF0046 /* NSImage+CGImage.swift */; };
 		D59CC1341D79AF5B00D72C39 /* Drawers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59CC1331D79AF5B00D72C39 /* Drawers.swift */; };
 		D59CC1361D79B00E00D72C39 /* UIImage+Modify.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59CC1351D79B00E00D72C39 /* UIImage+Modify.swift */; };
+		D59CC1381D79B23500D72C39 /* ImageDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59CC1371D79B23500D72C39 /* ImageDrawer.swift */; };
+		D59CC1391D79B23500D72C39 /* ImageDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59CC1371D79B23500D72C39 /* ImageDrawer.swift */; };
 		D5DF75B21C403FBF00BF1AB6 /* Cache.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5DF75B11C403FBF00BF1AB6 /* Cache.framework */; };
 /* End PBXBuildFile section */
 
@@ -53,6 +55,7 @@
 		D54225291D1D7ABD00AF0046 /* NSImage+CGImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSImage+CGImage.swift"; sourceTree = "<group>"; };
 		D59CC1331D79AF5B00D72C39 /* Drawers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Drawers.swift; sourceTree = "<group>"; };
 		D59CC1351D79B00E00D72C39 /* UIImage+Modify.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Modify.swift"; sourceTree = "<group>"; };
+		D59CC1371D79B23500D72C39 /* ImageDrawer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageDrawer.swift; sourceTree = "<group>"; };
 		D5DF75911C403D8200BF1AB6 /* Imaginary.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Imaginary.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5DF759E1C403E1000BF1AB6 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D5DF75B11C403FBF00BF1AB6 /* Cache.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cache.framework; path = Carthage/Build/iOS/Cache.framework; sourceTree = "<group>"; };
@@ -118,6 +121,7 @@
 				D2E6499F1D210A74002F9730 /* Image+Cache.swift */,
 				D2E649A21D210C1A002F9730 /* ImageView+Imaginary.swift */,
 				D2E649A91D210E37002F9730 /* Configuration.swift */,
+				D59CC1371D79B23500D72C39 /* ImageDrawer.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -368,6 +372,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D59CC1391D79B23500D72C39 /* ImageDrawer.swift in Sources */,
 				D2E649A81D210CDE002F9730 /* Decompressor.swift in Sources */,
 				D2E649A41D210C1A002F9730 /* ImageView+Imaginary.swift in Sources */,
 				D2E649981D2108F6002F9730 /* ImageView.swift in Sources */,
@@ -387,6 +392,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D59CC1341D79AF5B00D72C39 /* Drawers.swift in Sources */,
+				D59CC1381D79B23500D72C39 /* ImageDrawer.swift in Sources */,
 				D2E649AE1D21105F002F9730 /* Configuration+Imaginary.swift in Sources */,
 				D2E649A31D210C1A002F9730 /* ImageView+Imaginary.swift in Sources */,
 				D2E649A61D210CD4002F9730 /* Decompressor.swift in Sources */,

--- a/Imaginary.xcodeproj/project.pbxproj
+++ b/Imaginary.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		D54225251D1D7A9600AF0046 /* Capsule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54225211D1D7A9300AF0046 /* Capsule.swift */; };
 		D54225261D1D7A9900AF0046 /* NSHTTPURLResponse+Imaginary.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54225221D1D7A9300AF0046 /* NSHTTPURLResponse+Imaginary.swift */; };
 		D54225371D1D7AF100AF0046 /* NSImage+CGImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54225291D1D7ABD00AF0046 /* NSImage+CGImage.swift */; };
+		D59CC1341D79AF5B00D72C39 /* Drawers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59CC1331D79AF5B00D72C39 /* Drawers.swift */; };
+		D59CC1361D79B00E00D72C39 /* UIImage+Modify.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59CC1351D79B00E00D72C39 /* UIImage+Modify.swift */; };
 		D5DF75B21C403FBF00BF1AB6 /* Cache.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5DF75B11C403FBF00BF1AB6 /* Cache.framework */; };
 /* End PBXBuildFile section */
 
@@ -49,6 +51,8 @@
 		D54225211D1D7A9300AF0046 /* Capsule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Capsule.swift; sourceTree = "<group>"; };
 		D54225221D1D7A9300AF0046 /* NSHTTPURLResponse+Imaginary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSHTTPURLResponse+Imaginary.swift"; sourceTree = "<group>"; };
 		D54225291D1D7ABD00AF0046 /* NSImage+CGImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSImage+CGImage.swift"; sourceTree = "<group>"; };
+		D59CC1331D79AF5B00D72C39 /* Drawers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Drawers.swift; sourceTree = "<group>"; };
+		D59CC1351D79B00E00D72C39 /* UIImage+Modify.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Modify.swift"; sourceTree = "<group>"; };
 		D5DF75911C403D8200BF1AB6 /* Imaginary.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Imaginary.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5DF759E1C403E1000BF1AB6 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D5DF75B11C403FBF00BF1AB6 /* Cache.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cache.framework; path = Carthage/Build/iOS/Cache.framework; sourceTree = "<group>"; };
@@ -87,6 +91,7 @@
 		BDE8FBCD1D1BFA4F00C5A212 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
+				D59CC1321D79AF5100D72C39 /* Drawers */,
 				D2E649AC1D21105F002F9730 /* Extensions */,
 				D2E649A51D210CD4002F9730 /* Decompressor.swift */,
 			);
@@ -140,6 +145,15 @@
 				D54225291D1D7ABD00AF0046 /* NSImage+CGImage.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		D59CC1321D79AF5100D72C39 /* Drawers */ = {
+			isa = PBXGroup;
+			children = (
+				D59CC1331D79AF5B00D72C39 /* Drawers.swift */,
+				D59CC1351D79B00E00D72C39 /* UIImage+Modify.swift */,
+			);
+			path = Drawers;
 			sourceTree = "<group>";
 		};
 		D5DF75871C403D8200BF1AB6 = {
@@ -372,12 +386,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D59CC1341D79AF5B00D72C39 /* Drawers.swift in Sources */,
 				D2E649AE1D21105F002F9730 /* Configuration+Imaginary.swift in Sources */,
 				D2E649A31D210C1A002F9730 /* ImageView+Imaginary.swift in Sources */,
 				D2E649A61D210CD4002F9730 /* Decompressor.swift in Sources */,
 				D2E649941D2108EA002F9730 /* Image.swift in Sources */,
 				D54225241D1D7A9300AF0046 /* NSHTTPURLResponse+Imaginary.swift in Sources */,
 				D2E649971D2108F6002F9730 /* ImageView.swift in Sources */,
+				D59CC1361D79B00E00D72C39 /* UIImage+Modify.swift in Sources */,
 				D2E649A01D210A74002F9730 /* Image+Cache.swift in Sources */,
 				D2E649AA1D210E37002F9730 /* Configuration.swift in Sources */,
 				D54225231D1D7A9300AF0046 /* Capsule.swift in Sources */,

--- a/Sources/Mac/Extensions/Configuration+Imaginary.swift
+++ b/Sources/Mac/Extensions/Configuration+Imaginary.swift
@@ -29,4 +29,3 @@ public extension Configuration {
     imageView.layer?.opacity = 1.0
   }
 }
-

--- a/Sources/Shared/Fetcher.swift
+++ b/Sources/Shared/Fetcher.swift
@@ -31,7 +31,7 @@ class Fetcher {
 
   // MARK: - Fetching
 
-  func start(completion: (result: Result) -> Void) {
+  func start(preprocess: Preprocess, completion: (result: Result) -> Void) {
     active = true
 
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0)) { [weak self] in
@@ -62,10 +62,12 @@ class Fetcher {
           return
         }
 
-        guard let image = Image.decode(data) else {
+        guard let decodedImage = Image.decode(data) else {
           weakSelf.complete { completion(result: .Failure(Error.ConversionError)) }
           return
         }
+
+        let image = preprocess(decodedImage)
 
         if weakSelf.active {
           weakSelf.complete { completion(result: Result.Success(image)) }

--- a/Sources/Shared/Image.swift
+++ b/Sources/Shared/Image.swift
@@ -7,5 +7,3 @@ import Foundation
   import UIKit
   public typealias Image = UIImage
 #endif
-
-

--- a/Sources/Shared/ImageDrawer.swift
+++ b/Sources/Shared/ImageDrawer.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+#if os(OSX)
+  import Cocoa
+#else
+  import UIKit
+#endif
+
+public protocol ImageDrawer {
+  func draw(image: Image, context: CGContext, rect: CGRect)
+}

--- a/Sources/Shared/ImageDrawer.swift
+++ b/Sources/Shared/ImageDrawer.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 #if os(OSX)
   import Cocoa
 #else

--- a/Sources/Shared/ImageView+Imaginary.swift
+++ b/Sources/Shared/ImageView+Imaginary.swift
@@ -6,7 +6,7 @@ extension ImageView {
 
   public func setImage(URL: NSURL?,
                        placeholder: Image? = nil,
-                       preprocess: Preprocess = { image in return image },
+                       drawers: [ImageDrawer] = [],
                        completion: ((Image?) -> ())? = nil) {
     image = placeholder
 
@@ -36,6 +36,18 @@ extension ImageView {
       }
 
       weakSelf.fetcher = Fetcher(URL: URL)
+
+      let preprocess: Preprocess = { image in
+        guard !drawers.isEmpty else {
+          return image
+        }
+
+        guard let modifiedImage = image.modify(with: drawers) else {
+          return image
+        }
+
+        return modifiedImage
+      }
 
       weakSelf.fetcher?.start(preprocess) { [weak self] result in
         guard let weakSelf = self else { return }

--- a/Sources/Shared/ImageView+Imaginary.swift
+++ b/Sources/Shared/ImageView+Imaginary.swift
@@ -6,7 +6,7 @@ extension ImageView {
 
   public func setImage(URL: NSURL?,
                        placeholder: Image? = nil,
-                       drawers: [ImageDrawer] = [],
+                       preprocess: Preprocess = { image in return image },
                        completion: ((Image?) -> ())? = nil) {
     image = placeholder
 
@@ -36,18 +36,6 @@ extension ImageView {
       }
 
       weakSelf.fetcher = Fetcher(URL: URL)
-
-      let preprocess: Preprocess = { image in
-        guard !drawers.isEmpty else {
-          return image
-        }
-
-        guard let modifiedImage = image.modify(with: drawers) else {
-          return image
-        }
-
-        return modifiedImage
-      }
 
       weakSelf.fetcher?.start(preprocess) { [weak self] result in
         guard let weakSelf = self else { return }

--- a/Sources/Shared/ImageView+Imaginary.swift
+++ b/Sources/Shared/ImageView+Imaginary.swift
@@ -1,8 +1,13 @@
 import Foundation
 
+public typealias Preprocess = Image -> Image
+
 extension ImageView {
 
-  public func setImage(URL: NSURL?, placeholder: Image? = nil, completion: ((Image?) -> ())? = nil) {
+  public func setImage(URL: NSURL?,
+                       placeholder: Image? = nil,
+                       preprocess: Preprocess = { image in return image },
+                       completion: ((Image?) -> ())? = nil) {
     image = placeholder
 
     guard let URL = URL else { return }
@@ -32,7 +37,7 @@ extension ImageView {
 
       weakSelf.fetcher = Fetcher(URL: URL)
 
-      weakSelf.fetcher?.start { [weak self] result in
+      weakSelf.fetcher?.start(preprocess) { [weak self] result in
         guard let weakSelf = self else { return }
 
         switch result {

--- a/Sources/iOS/Drawers/Drawers.swift
+++ b/Sources/iOS/Drawers/Drawers.swift
@@ -1,9 +1,32 @@
-//
-//  Drawers.swift
-//  Imaginary
-//
-//  Created by Vadym Markov on 02/09/16.
-//  Copyright © 2016 Hyper Interaktiv AS. All rights reserved.
-//
+import UIKit
 
-import Foundation
+public protocol ImageDrawer {
+  func draw(image: UIImage, context: CGContext, rect: CGRect)
+}
+
+// MARK: - Tint effect
+
+public struct TintDrawer: ImageDrawer {
+
+  public let tintColor: UIColor
+
+  public init(tintColor: UIColor) {
+    self.tintColor = tintColor
+  }
+
+  public func draw(image: UIImage, context: CGContext, rect: CGRect) {
+    CGContextSetBlendMode(context, .Normal)
+    UIColor.blackColor().setFill()
+    CGContextFillRect(context, rect)
+
+    CGContextSetBlendMode(context, .Normal)
+    CGContextDrawImage(context, rect, image.CGImage)
+
+    CGContextSetBlendMode(context, .Color)
+    tintColor.setFill()
+    CGContextFillRect(context, rect)
+
+    CGContextSetBlendMode(context, .DestinationIn)
+    CGContextDrawImage(context, rect, image.CGImage)
+  }
+}

--- a/Sources/iOS/Drawers/Drawers.swift
+++ b/Sources/iOS/Drawers/Drawers.swift
@@ -1,6 +1,5 @@
 import UIKit
 
-
 // MARK: - Tint effect
 
 public struct TintDrawer: ImageDrawer {

--- a/Sources/iOS/Drawers/Drawers.swift
+++ b/Sources/iOS/Drawers/Drawers.swift
@@ -1,0 +1,9 @@
+//
+//  Drawers.swift
+//  Imaginary
+//
+//  Created by Vadym Markov on 02/09/16.
+//  Copyright © 2016 Hyper Interaktiv AS. All rights reserved.
+//
+
+import Foundation

--- a/Sources/iOS/Drawers/Drawers.swift
+++ b/Sources/iOS/Drawers/Drawers.swift
@@ -1,8 +1,5 @@
 import UIKit
 
-public protocol ImageDrawer {
-  func draw(image: UIImage, context: CGContext, rect: CGRect)
-}
 
 // MARK: - Tint effect
 

--- a/Sources/iOS/Drawers/UIImage+Modify.swift
+++ b/Sources/iOS/Drawers/UIImage+Modify.swift
@@ -2,7 +2,7 @@ import UIKit
 
 public extension UIImage {
 
-  func modify(with drawers: ImageDrawer...) -> UIImage? {
+  func modify(with drawers: [ImageDrawer]) -> UIImage? {
     UIGraphicsBeginImageContextWithOptions(size, false, scale)
 
     guard let context = UIGraphicsGetCurrentContext() else {

--- a/Sources/iOS/Drawers/UIImage+Modify.swift
+++ b/Sources/iOS/Drawers/UIImage+Modify.swift
@@ -1,0 +1,26 @@
+import UIKit
+
+public extension UIImage {
+
+  func modify(with drawers: ImageDrawer...) -> UIImage? {
+    UIGraphicsBeginImageContextWithOptions(size, false, scale)
+
+    guard let context = UIGraphicsGetCurrentContext() else {
+      return nil
+    }
+
+    let rect = CGRect(x: 0, y: 0, width: size.width, height: size.height)
+
+    CGContextTranslateCTM(context, 0, size.height)
+    CGContextScaleCTM(context, 1.0, -1.0)
+
+    for drawer in drawers {
+      drawer.draw(self, context: context, rect: rect)
+    }
+
+    let image = UIGraphicsGetImageFromCurrentImageContext()
+    UIGraphicsEndImageContext()
+
+    return image
+  }
+}


### PR DESCRIPTION
Now you can pass a list of "drawers" to modify an image before it will be saved in cache and displayed on the screen:

``` swift
setImage(imageURL, preprocess: { image in
  let effect = TintDrawer(tintColor: color)
  return image.modify(with: effect) ?? image
})
```

`TintDrawer` is an implementation of color blend effect. It might be nice feature if we have more "preprocessors" like that in the library.
