### PR TITLE
Add track function to track error

### DIFF
--- a/Example/ImaginaryDemo/Podfile.lock
+++ b/Example/ImaginaryDemo/Podfile.lock
@@ -2,8 +2,8 @@ PODS:
   - Cache (2.0.0):
     - CryptoSwift
   - CryptoSwift (0.6.1)
-  - Imaginary (0.1.0):
-    - Cache
+  - Imaginary (1.0.1):
+    - Cache (~> 2.0)
 
 DEPENDENCIES:
   - Cache
@@ -17,8 +17,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Cache: 86c7a082ce5a734df15a103581d81d29002a171e
   CryptoSwift: abdbc1bf32c89117c6b403810a7b30f742d86e68
-  Imaginary: 62a9ce1e6d7831ede429c8221a183f03ec2a90bc
+  Imaginary: d0aede1399f7a5e401428d54ee75dddaaea65e4e
 
 PODFILE CHECKSUM: 6c3e9cf6a12cbdd6952efb6b00ddfb2139144199
 
-COCOAPODS: 1.1.0.rc.3
+COCOAPODS: 1.1.1

--- a/Sources/Shared/ImageView+Imaginary.swift
+++ b/Sources/Shared/ImageView+Imaginary.swift
@@ -45,9 +45,10 @@ extension ImageView {
           Configuration.transitionClosure(weakSelf, image)
           Configuration.imageCache.add(key, object: image)
           completion?(image)
-        default:
-          break
+        case let .failure(error):
+          Configuration.track?(url, error)
         }
+        
         Configuration.postConfigure?(weakSelf)
       }
     }

--- a/Sources/iOS/Extensions/Configuration+Imaginary.swift
+++ b/Sources/iOS/Extensions/Configuration+Imaginary.swift
@@ -28,4 +28,6 @@ public extension Configuration {
     imageView.layer.add(animation, forKey: "fadeAnimation")
     imageView.layer.opacity = 1.0
   }
+  
+  public static var track: ((_ url: URL?, _ error: Error) -> Void)?
 }


### PR DESCRIPTION
This could be useful in case we want to track a loading failure. Then we can use it like

```swift
Configuration.track = { (url, error) in
   print(url)
   print(error as? NSError)
}
```