### PR TITLE
Update closure reference

### DIFF
--- a/Sources/Shared/ImageView+Imaginary.swift
+++ b/Sources/Shared/ImageView+Imaginary.swift
@@ -34,7 +34,9 @@ extension ImageView {
         Configuration.preConfigure?(weakSelf)
       }
 
-      weakSelf.fetchFromNetwork(url: url, preprocess: preprocess, completion: completion)
+      DispatchQueue.main.async {
+        weakSelf.fetchFromNetwork(url: url, preprocess: preprocess, completion: completion)
+      }
     }
   }
 


### PR DESCRIPTION
- There are some errors like `incorrect checksum for freed object - object was probably modified after being freed` that may relate to inner closure reference.

  - https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20151207/001197.html
  - http://blog.xebia.com/swift-self-reference-in-inner-closure/

From testing https://gist.github.com/onmyway133/0c76f56c52e4c3a4c0d705481dfaacbc, I see that there's nothing wrong. But I think it's easy to reason with another helper function

- Running Thead Sanitizer, we have some warnings about accessing `fetcher` from `main queue` and from `cache queue`. This fixes by wrapping the call inside `main queue` so that actions are processed serially