### PR TITLE
Improve tracking methods by returning the bytes that Imaginary has loaded

### DIFF
--- a/Sources/Shared/Configuration.swift
+++ b/Sources/Shared/Configuration.swift
@@ -3,6 +3,7 @@ import Cache
 
 public struct Configuration {
 
+  public static var bytesLoaded: Int = 0
   public static var imageCache: Cache<Image> = {
     let config = Config(
         frontKind: .memory,

--- a/Sources/Shared/Fetcher.swift
+++ b/Sources/Shared/Fetcher.swift
@@ -3,7 +3,7 @@ import Foundation
 class Fetcher {
 
   enum Result {
-    case success(Image)
+    case success(Image, Int)
     case failure(Error)
   }
 
@@ -69,9 +69,11 @@ class Fetcher {
 
         let image = preprocess(decodedImage)
 
+        Configuration.bytesLoaded += data.count
+
         if weakSelf.active {
           weakSelf.complete {
-            completion(Result.success(image))
+            completion(Result.success(image, data.count))
           }
         }
       })

--- a/Sources/Shared/ImageView+Imaginary.swift
+++ b/Sources/Shared/ImageView+Imaginary.swift
@@ -50,6 +50,7 @@ extension ImageView {
 
       switch result {
       case let .success(image):
+        Configuration.track?(url, nil)
         Configuration.transitionClosure(weakSelf, image)
         Configuration.imageCache.add(url.absoluteString, object: image)
         completion?(image)

--- a/Sources/Shared/ImageView+Imaginary.swift
+++ b/Sources/Shared/ImageView+Imaginary.swift
@@ -54,6 +54,8 @@ extension ImageView {
         Configuration.transitionClosure(weakSelf, image)
         Configuration.imageCache.add(url.absoluteString, object: image)
         completion?(image)
+
+        Configuration.bytesLoaded += image.memorySize
       case let .failure(error):
         Configuration.track?(url, error)
       }

--- a/Sources/Shared/ImageView+Imaginary.swift
+++ b/Sources/Shared/ImageView+Imaginary.swift
@@ -49,15 +49,13 @@ extension ImageView {
       guard let weakSelf = self else { return }
 
       switch result {
-      case let .success(image):
-        Configuration.track?(url, nil)
+      case let .success(image, bytes):
+        Configuration.track?(url, nil, bytes)
         Configuration.transitionClosure(weakSelf, image)
         Configuration.imageCache.add(url.absoluteString, object: image)
         completion?(image)
-
-        Configuration.bytesLoaded += image.memorySize
       case let .failure(error):
-        Configuration.track?(url, error)
+        Configuration.track?(url, error, 0)
       }
 
       Configuration.postConfigure?(weakSelf)

--- a/Sources/iOS/Extensions/Configuration+Imaginary.swift
+++ b/Sources/iOS/Extensions/Configuration+Imaginary.swift
@@ -29,5 +29,5 @@ public extension Configuration {
     imageView.layer.opacity = 1.0
   }
   
-  public static var track: ((_ url: URL?, _ error: Error?) -> Void)?
+  public static var track: ((URL?, Error?, Int) -> Void)?
 }

--- a/Sources/iOS/Extensions/Configuration+Imaginary.swift
+++ b/Sources/iOS/Extensions/Configuration+Imaginary.swift
@@ -29,5 +29,5 @@ public extension Configuration {
     imageView.layer.opacity = 1.0
   }
   
-  public static var track: ((_ url: URL?, _ error: Error) -> Void)?
+  public static var track: ((_ url: URL?, _ error: Error?) -> Void)?
 }


### PR DESCRIPTION
This PR improves the `track` method on `Configuration` by return the amount of bytes that `Imaginary` has consumed. This is useful when optimizing data loading in your application.

So to gather data and debug in your application, you would do something like this:

```swift
    Imaginary.Configuration.track = { (url, error, bytes) in
      let kb = bytes / 1024
      let totalKb = Configuration.bytesLoaded / 1024
      let total: String

      if totalKb / 1024 >= 1 {
        total = String(format: "%.2f mb", (Float(totalKb) / 1024.0))
      } else {
        total = "\(totalKb)kb"
      }

      if let error = error {
        print("⚠️ Something went wrong: \(error) -> \(url)")
      }

      print("🌅 \(url) -> \(kb)kb")
      print("total loaded: \(total)")
    }
```