### PR TITLE
Update Cartfile and Example Podfile's

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "hyperoslo/Cache" "master"
+github "hyperoslo/Cache" ~> 3.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "hyperoslo/Cache" "e248589dde631b5c51f300c986ecd23e680aa6fd"
-github "onmyway133/SwiftHash" "1.3.0"
+github "hyperoslo/Cache" "3.0.0"
+github "onmyway133/SwiftHash" "1.4.0"

--- a/Example/ImaginaryDemo/Podfile
+++ b/Example/ImaginaryDemo/Podfile
@@ -4,6 +4,5 @@ use_frameworks!
 inhibit_all_warnings!
 
 pod 'Imaginary', path: '../../'
-pod 'Cache', git: 'https://github.com/hyperoslo/Cache'
 
 target 'ImaginaryDemo'

--- a/Example/ImaginaryDemo/Podfile.lock
+++ b/Example/ImaginaryDemo/Podfile.lock
@@ -1,30 +1,22 @@
 PODS:
   - Cache (3.0.0):
-    - SwiftHash (~> 1.3.0)
+    - SwiftHash (~> 1.4.0)
   - Imaginary (1.0.2):
     - Cache (~> 3.0)
-  - SwiftHash (1.3.0)
+  - SwiftHash (1.4.0)
 
 DEPENDENCIES:
-  - Cache (from `https://github.com/hyperoslo/Cache`)
   - Imaginary (from `../../`)
 
 EXTERNAL SOURCES:
-  Cache:
-    :git: https://github.com/hyperoslo/Cache
   Imaginary:
     :path: "../../"
 
-CHECKOUT OPTIONS:
-  Cache:
-    :commit: 199a19a445fe5c5db1f75b59d65a220fc96ed8ea
-    :git: https://github.com/hyperoslo/Cache
-
 SPEC CHECKSUMS:
-  Cache: 82e21eb6c7b7dfb1af87c0439367c5d9b449a498
+  Cache: 50fdd9dea71ba7d3efe39bf6bef555701509b16a
   Imaginary: 3135892ca46c5126cf94df3340e10e267066bd12
-  SwiftHash: f924b916b77236ba2aa14d12c70e71314e66eb06
+  SwiftHash: acf0f29032309a5c7a7f625595eade1aca97aca2
 
-PODFILE CHECKSUM: 5423981f679c1c6856d55cb3e71454acd168ec0a
+PODFILE CHECKSUM: cc0015ab41f8105ed6a3d704c4ac339720e31e09
 
 COCOAPODS: 1.2.1

--- a/Example/ImaginaryForMac/Podfile
+++ b/Example/ImaginaryForMac/Podfile
@@ -5,6 +5,5 @@ inhibit_all_warnings!
 
 
 pod 'Imaginary', path: '../../'
-pod 'Cache', git: 'https://github.com/hyperoslo/Cache'
 
 target 'ImaginaryForMac'

--- a/Example/ImaginaryForMac/Podfile.lock
+++ b/Example/ImaginaryForMac/Podfile.lock
@@ -1,30 +1,22 @@
 PODS:
   - Cache (3.0.0):
-    - SwiftHash (~> 1.3.0)
+    - SwiftHash (~> 1.4.0)
   - Imaginary (1.0.2):
     - Cache (~> 3.0)
-  - SwiftHash (1.3.0)
+  - SwiftHash (1.4.0)
 
 DEPENDENCIES:
-  - Cache (from `https://github.com/hyperoslo/Cache`)
   - Imaginary (from `../../`)
 
 EXTERNAL SOURCES:
-  Cache:
-    :git: https://github.com/hyperoslo/Cache
   Imaginary:
     :path: "../../"
 
-CHECKOUT OPTIONS:
-  Cache:
-    :commit: 199a19a445fe5c5db1f75b59d65a220fc96ed8ea
-    :git: https://github.com/hyperoslo/Cache
-
 SPEC CHECKSUMS:
-  Cache: 82e21eb6c7b7dfb1af87c0439367c5d9b449a498
+  Cache: 50fdd9dea71ba7d3efe39bf6bef555701509b16a
   Imaginary: 3135892ca46c5126cf94df3340e10e267066bd12
-  SwiftHash: f924b916b77236ba2aa14d12c70e71314e66eb06
+  SwiftHash: acf0f29032309a5c7a7f625595eade1aca97aca2
 
-PODFILE CHECKSUM: cbb498067d711a0ef60b73f3428a330b9cdde7e2
+PODFILE CHECKSUM: 804905a0cfc064a8a0388d223095e41774bcee31
 
 COCOAPODS: 1.2.1


### PR DESCRIPTION
Locks the version of `Cache` to version 3.x.x for examples and Carthage.