### PR TITLE
Fix/dispatch

### DIFF
--- a/Sources/Shared/ImageView+Imaginary.swift
+++ b/Sources/Shared/ImageView+Imaginary.swift
@@ -35,7 +35,9 @@ extension ImageView {
       }
 
       if placeholder == nil {
-        Configuration.preConfigure?(weakSelf)
+        DispatchQueue.main.async {
+          Configuration.preConfigure?(weakSelf)
+        }
       }
 
       DispatchQueue.main.async {


### PR DESCRIPTION
Fix dispatch queue error having `preConfigure` run in a different
thread than `main`. Because the `preConfigure` most likely will interact with UI, it should
always run in the main thread.