### PR TITLE
Improve overall code style and move type aliases into one file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
     - Carthage
 
 before_install:
-  - carthage bootstrap --platform iOS,Mac,tvOS
+  - travis_wait 35; bin/bootstrap-if-needed
 
 script:
   - xcodebuild clean build -project Imaginary.xcodeproj -scheme "Imaginary-Mac" -sdk macosx | xcpretty

--- a/Example/ImaginaryDemo/Podfile.lock
+++ b/Example/ImaginaryDemo/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Cache (3.0.0):
+  - Cache (3.1.0):
     - SwiftHash (~> 1.4.0)
   - Imaginary (1.0.2):
     - Cache (~> 3.0)
@@ -13,7 +13,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  Cache: 50fdd9dea71ba7d3efe39bf6bef555701509b16a
+  Cache: 6dea29625ee40c1cafb2ff6c48f3f7341a59cfb5
   Imaginary: 3135892ca46c5126cf94df3340e10e267066bd12
   SwiftHash: acf0f29032309a5c7a7f625595eade1aca97aca2
 

--- a/Example/ImaginaryForMac/Podfile.lock
+++ b/Example/ImaginaryForMac/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Cache (3.0.0):
+  - Cache (3.1.0):
     - SwiftHash (~> 1.4.0)
   - Imaginary (1.0.2):
     - Cache (~> 3.0)
@@ -13,7 +13,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  Cache: 50fdd9dea71ba7d3efe39bf6bef555701509b16a
+  Cache: 6dea29625ee40c1cafb2ff6c48f3f7341a59cfb5
   Imaginary: 3135892ca46c5126cf94df3340e10e267066bd12
   SwiftHash: acf0f29032309a5c7a7f625595eade1aca97aca2
 

--- a/Imaginary.xcodeproj/project.pbxproj
+++ b/Imaginary.xcodeproj/project.pbxproj
@@ -7,11 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BDA7AE451EEA925600E09EBC /* TypeAlias.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA7AE441EEA925600E09EBC /* TypeAlias.swift */; };
+		BDA7AE461EEA925600E09EBC /* TypeAlias.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA7AE441EEA925600E09EBC /* TypeAlias.swift */; };
 		BDE8FBF61D1BFC8D00C5A212 /* Cache.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDE8FBF51D1BFC8D00C5A212 /* Cache.framework */; };
-		D2E649941D2108EA002F9730 /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E649931D2108EA002F9730 /* Image.swift */; };
-		D2E649951D2108EA002F9730 /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E649931D2108EA002F9730 /* Image.swift */; };
-		D2E649971D2108F6002F9730 /* ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E649961D2108F6002F9730 /* ImageView.swift */; };
-		D2E649981D2108F6002F9730 /* ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E649961D2108F6002F9730 /* ImageView.swift */; };
 		D2E6499D1D2109A2002F9730 /* Fetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E6499A1D2109A2002F9730 /* Fetcher.swift */; };
 		D2E6499E1D2109A2002F9730 /* Fetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E6499A1D2109A2002F9730 /* Fetcher.swift */; };
 		D2E649A01D210A74002F9730 /* Image+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E6499F1D210A74002F9730 /* Image+Cache.swift */; };
@@ -37,11 +35,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		BDA7AE441EEA925600E09EBC /* TypeAlias.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeAlias.swift; sourceTree = "<group>"; };
 		BDE8FBE91D1BFB9F00C5A212 /* Imaginary.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Imaginary.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDE8FBF41D1BFC7C00C5A212 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BDE8FBF51D1BFC8D00C5A212 /* Cache.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cache.framework; path = Carthage/Build/Mac/Cache.framework; sourceTree = "<group>"; };
-		D2E649931D2108EA002F9730 /* Image.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
-		D2E649961D2108F6002F9730 /* ImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
 		D2E6499A1D2109A2002F9730 /* Fetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Fetcher.swift; sourceTree = "<group>"; };
 		D2E6499F1D210A74002F9730 /* Image+Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Image+Cache.swift"; sourceTree = "<group>"; };
 		D2E649A21D210C1A002F9730 /* ImageView+Imaginary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ImageView+Imaginary.swift"; sourceTree = "<group>"; };
@@ -113,15 +110,14 @@
 		BDE8FBD61D1BFA4F00C5A212 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
-				D2E6499A1D2109A2002F9730 /* Fetcher.swift */,
 				D54225211D1D7A9300AF0046 /* Capsule.swift */,
-				D54225221D1D7A9300AF0046 /* NSHTTPURLResponse+Imaginary.swift */,
-				D2E649931D2108EA002F9730 /* Image.swift */,
-				D2E649961D2108F6002F9730 /* ImageView.swift */,
-				D2E6499F1D210A74002F9730 /* Image+Cache.swift */,
-				D2E649A21D210C1A002F9730 /* ImageView+Imaginary.swift */,
 				D2E649A91D210E37002F9730 /* Configuration.swift */,
+				D2E6499A1D2109A2002F9730 /* Fetcher.swift */,
+				D2E6499F1D210A74002F9730 /* Image+Cache.swift */,
 				D59CC1371D79B23500D72C39 /* ImageDrawer.swift */,
+				D2E649A21D210C1A002F9730 /* ImageView+Imaginary.swift */,
+				D54225221D1D7A9300AF0046 /* NSHTTPURLResponse+Imaginary.swift */,
+				BDA7AE441EEA925600E09EBC /* TypeAlias.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -384,13 +380,12 @@
 				D59CC1391D79B23500D72C39 /* ImageDrawer.swift in Sources */,
 				D2E649A81D210CDE002F9730 /* Decompressor.swift in Sources */,
 				D2E649A41D210C1A002F9730 /* ImageView+Imaginary.swift in Sources */,
-				D2E649981D2108F6002F9730 /* ImageView.swift in Sources */,
 				D2E649B01D211067002F9730 /* Configuration+Imaginary.swift in Sources */,
 				D54225251D1D7A9600AF0046 /* Capsule.swift in Sources */,
 				D2E649AB1D210E37002F9730 /* Configuration.swift in Sources */,
-				D2E649951D2108EA002F9730 /* Image.swift in Sources */,
 				D2E6499E1D2109A2002F9730 /* Fetcher.swift in Sources */,
 				D2E649A11D210A74002F9730 /* Image+Cache.swift in Sources */,
+				BDA7AE461EEA925600E09EBC /* TypeAlias.swift in Sources */,
 				D54225371D1D7AF100AF0046 /* NSImage+CGImage.swift in Sources */,
 				D54225261D1D7A9900AF0046 /* NSHTTPURLResponse+Imaginary.swift in Sources */,
 			);
@@ -402,12 +397,11 @@
 			files = (
 				D59CC1341D79AF5B00D72C39 /* Drawers.swift in Sources */,
 				D59CC1381D79B23500D72C39 /* ImageDrawer.swift in Sources */,
+				BDA7AE451EEA925600E09EBC /* TypeAlias.swift in Sources */,
 				D2E649AE1D21105F002F9730 /* Configuration+Imaginary.swift in Sources */,
 				D2E649A31D210C1A002F9730 /* ImageView+Imaginary.swift in Sources */,
 				D2E649A61D210CD4002F9730 /* Decompressor.swift in Sources */,
-				D2E649941D2108EA002F9730 /* Image.swift in Sources */,
 				D54225241D1D7A9300AF0046 /* NSHTTPURLResponse+Imaginary.swift in Sources */,
-				D2E649971D2108F6002F9730 /* ImageView.swift in Sources */,
 				D59CC1361D79B00E00D72C39 /* UIImage+Modify.swift in Sources */,
 				D2E649A01D210A74002F9730 /* Image+Cache.swift in Sources */,
 				D2E649AA1D210E37002F9730 /* Configuration.swift in Sources */,

--- a/Sources/Mac/Decompressor.swift
+++ b/Sources/Mac/Decompressor.swift
@@ -1,16 +1,21 @@
 import Cocoa
 
 struct Decompressor {
-
   static func decompress(_ data: Data, scale: CGFloat = 1) -> NSImage {
-    guard let image = NSImage(data: data) else { return NSImage() }
+    guard let image = NSImage(data: data) else {
+      return NSImage()
+    }
 
     image.lockFocus()
 
     var imageRect: CGRect = CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height)
-    guard let imageRef = image.cgImage(forProposedRect: &imageRect, context: nil, hints: nil) else { return image }
+    guard let imageRef = image.cgImage(forProposedRect: &imageRect, context: nil, hints: nil) else {
+      return image
+    }
 
-    if imageRef.alphaInfo != .none { return image }
+    if imageRef.alphaInfo != .none {
+      return image
+    }
 
     let width = imageRef.width
     let height = imageRef.height
@@ -26,7 +31,10 @@ struct Decompressor {
                               bitsPerComponent: bitsPerComponent,
                               bytesPerRow: bytesPerRow,
                               space: colorSpaceRef,
-                              bitmapInfo: CGBitmapInfo.byteOrder32Big.rawValue) else { return image }
+                              bitmapInfo: CGBitmapInfo.byteOrder32Big.rawValue) else {
+                                return image
+
+    }
 
     context.draw(imageRef, in: CGRect(x: 0, y: 0, width: CGFloat(width), height: CGFloat(height)))
 

--- a/Sources/Mac/Extensions/Configuration+Imaginary.swift
+++ b/Sources/Mac/Extensions/Configuration+Imaginary.swift
@@ -2,12 +2,11 @@ import Cocoa
 import Cache
 
 public extension Configuration {
-
-  public static var preConfigure: ((_ imageView: NSImageView) -> Void)? = { imageView in
+  public static var preConfigure: ((NSImageView) -> Void)? = { imageView in
     imageView.layer?.opacity = 0.0
   }
 
-  public static var transitionClosure: ((_ imageView: NSImageView, _ image: NSImage) -> Void) = { imageView, newImage in
+  public static var transitionClosure: ((NSImageView, NSImage) -> Void) = { imageView, newImage in
     guard let oldImage = imageView.image else {
       imageView.image = newImage
       return

--- a/Sources/Mac/Extensions/NSImage+CGImage.swift
+++ b/Sources/Mac/Extensions/NSImage+CGImage.swift
@@ -1,7 +1,6 @@
 import Cocoa
 
 extension NSImage {
-
   var cgImage: CGImage? {
     guard let data = tiffRepresentation,
       let source = CGImageSourceCreateWithData(data as CFData, nil),

--- a/Sources/Shared/Capsule.swift
+++ b/Sources/Shared/Capsule.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 class Capsule: NSObject {
-
   static var ObjectKey = 0
   let concept: Any
 

--- a/Sources/Shared/Configuration.swift
+++ b/Sources/Shared/Configuration.swift
@@ -2,9 +2,7 @@ import Foundation
 import Cache
 
 public struct Configuration {
-
   public static var bytesLoaded: Int = 0
-
   public static var imageCache: SpecializedCache<Image> = {
     let config = Config(
         expiry: Expiry.date(NSDate().addingTimeInterval(60 * 60 * 24 * 3) as Date),

--- a/Sources/Shared/Fetcher.swift
+++ b/Sources/Shared/Fetcher.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 class Fetcher {
-
   enum Result {
     case success(image: Image, byteCount: Int)
     case failure(Error)
@@ -35,35 +34,38 @@ class Fetcher {
     active = true
 
     DispatchQueue.global(qos: DispatchQoS.QoSClass.background).async { [weak self] in
-      guard let weakSelf = self, weakSelf.active else { return }
+      guard let `self` = self, self.active else {
+        return
+      }
 
-      weakSelf.task = weakSelf.session.dataTask(with: weakSelf.url, completionHandler: {
-        [weak self] data, response, error -> Void in
+      self.task = self.session.dataTask(with: self.url, completionHandler: { [weak self] data, response, error -> Void in
 
-        guard let weakSelf = self, weakSelf.active else { return }
+        guard let `self` = self, self.active else {
+          return
+        }
 
         if let error = error {
-          weakSelf.complete { completion(.failure(error)) }
+          self.complete { completion(.failure(error)) }
           return
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-          weakSelf.complete { completion(.failure(Failure.invalidResponse)) }
+          self.complete { completion(.failure(Failure.invalidResponse)) }
           return
         }
 
         guard httpResponse.statusCode == 200 else {
-          weakSelf.complete { completion(.failure(Failure.invalidStatusCode)) }
+          self.complete { completion(.failure(Failure.invalidStatusCode)) }
           return
         }
 
         guard let data = data, httpResponse.validateLength(data) else {
-          weakSelf.complete { completion(.failure(Failure.invalidContentLength)) }
+          self.complete { completion(.failure(Failure.invalidContentLength)) }
           return
         }
 
         guard let decodedImage = Image.decode(data) else {
-          weakSelf.complete { completion(.failure(Failure.conversionError)) }
+          self.complete { completion(.failure(Failure.conversionError)) }
           return
         }
 
@@ -71,14 +73,14 @@ class Fetcher {
 
         Configuration.bytesLoaded += data.count
 
-        if weakSelf.active {
-          weakSelf.complete {
+        if self.active {
+          self.complete {
             completion(Result.success(image: image, byteCount: data.count))
           }
         }
       })
 
-      weakSelf.task?.resume()
+      self.task?.resume()
     }
   }
 

--- a/Sources/Shared/Image+Cache.swift
+++ b/Sources/Shared/Image+Cache.swift
@@ -2,9 +2,7 @@ import Foundation
 import Cache
 
 extension Image {
-
   public typealias CacheType = Image
-
   public static func decode(_ data: Data) -> CacheType? {
     return Decompressor.decompress(data as Data)
   }

--- a/Sources/Shared/Image.swift
+++ b/Sources/Shared/Image.swift
@@ -1,9 +1,0 @@
-import Foundation
-
-#if os(OSX)
-  import Cocoa
-  public typealias Image = NSImage
-#else
-  import UIKit
-  public typealias Image = UIImage
-#endif

--- a/Sources/Shared/ImageDrawer.swift
+++ b/Sources/Shared/ImageDrawer.swift
@@ -1,8 +1,4 @@
-#if os(OSX)
-  import Cocoa
-#else
-  import UIKit
-#endif
+import CoreGraphics
 
 public protocol ImageDrawer {
   func draw(_ image: Image, context: CGContext, rect: CGRect)

--- a/Sources/Shared/ImageView.swift
+++ b/Sources/Shared/ImageView.swift
@@ -1,9 +1,0 @@
-import Foundation
-
-#if os(OSX)
-  import Cocoa
-  public typealias ImageView = NSImageView
-#else
-  import UIKit
-  public typealias ImageView = UIImageView
-#endif

--- a/Sources/Shared/NSHTTPURLResponse+Imaginary.swift
+++ b/Sources/Shared/NSHTTPURLResponse+Imaginary.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 extension HTTPURLResponse {
-
   func validateLength(_ data: Data) -> Bool {
     return expectedContentLength > -1
       ? (Int64(data.count) >= expectedContentLength)

--- a/Sources/Shared/TypeAlias.swift
+++ b/Sources/Shared/TypeAlias.swift
@@ -1,0 +1,17 @@
+// This file contains a collection of type aliases to make
+// the implementation more unified. Instead of referencing
+// platform specific UI objects, we make type aliases to point
+// to different implementations depending on the platform.
+
+#if os(OSX)
+  import Cocoa
+  public typealias Image = NSImage
+  public typealias ImageView = NSImageView
+#else
+  import UIKit
+  public typealias Image = UIImage
+  public typealias ImageView = UIImageView
+#endif
+
+public typealias Preprocess = (Image) -> Image
+public typealias Completion = (Image?) -> Void

--- a/Sources/iOS/Decompressor.swift
+++ b/Sources/iOS/Decompressor.swift
@@ -1,15 +1,18 @@
 import UIKit
 
 struct Decompressor {
-
   static func decompress(_ data: Data, scale: CGFloat = 1) -> Image {
-    guard let image = Image(data: data) else { return Image() }
+    guard let image = Image(data: data) else {
+      return Image()
+    }
 
     guard let imageRef = image.cgImage, let colorSpaceRef = imageRef.colorSpace else {
       return image
     }
 
-    if imageRef.alphaInfo != .none { return image }
+    if imageRef.alphaInfo != .none {
+      return image
+    }
 
     let width = imageRef.width
     let height = imageRef.height

--- a/Sources/iOS/Drawers/Drawers.swift
+++ b/Sources/iOS/Drawers/Drawers.swift
@@ -3,7 +3,6 @@ import UIKit
 // MARK: - Tint effect
 
 public struct TintDrawer: ImageDrawer {
-
   public let tintColor: UIColor
 
   public init(tintColor: UIColor) {

--- a/Sources/iOS/Drawers/UIImage+Modify.swift
+++ b/Sources/iOS/Drawers/UIImage+Modify.swift
@@ -1,7 +1,6 @@
 import UIKit
 
 public extension UIImage {
-
   func modify(with drawers: [ImageDrawer]) -> UIImage? {
     UIGraphicsBeginImageContextWithOptions(size, false, scale)
 

--- a/Sources/iOS/Extensions/Configuration+Imaginary.swift
+++ b/Sources/iOS/Extensions/Configuration+Imaginary.swift
@@ -2,12 +2,11 @@ import UIKit
 import Cache
 
 public extension Configuration {
-
-  public static var preConfigure: ((_ imageView: UIImageView) -> Void)? = { imageView in
+  public static var preConfigure: ((UIImageView) -> Void)? = { imageView in
     imageView.layer.opacity = 0.0
   }
 
-  public static var transitionClosure: ((_ imageView: UIImageView, _ image: UIImage) -> Void) = { imageView, newImage in
+  public static var transitionClosure: ((UIImageView, UIImage) -> Void) = { imageView, newImage in
     guard let oldImage = imageView.image else {
       imageView.image = newImage
       return


### PR DESCRIPTION
Remove the extra newline that we have in all class and struct
declarations.

Improve debug-ability with `guard`'s. The `else` closure now has
newlines so that you can set breaking points more easily.

Type aliases has been moved into on single file.

`weakSelf` is no `self`.