### PR TITLE
Feature ImageManager for fetching image without using an image view

### DIFF
--- a/Imaginary.xcodeproj/project.pbxproj
+++ b/Imaginary.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BD92A5A41F01089A008408AB /* ImageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD92A5A31F01089A008408AB /* ImageManager.swift */; };
+		BD92A5A51F01089A008408AB /* ImageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD92A5A31F01089A008408AB /* ImageManager.swift */; };
 		BDA7AE451EEA925600E09EBC /* TypeAlias.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA7AE441EEA925600E09EBC /* TypeAlias.swift */; };
 		BDA7AE461EEA925600E09EBC /* TypeAlias.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA7AE441EEA925600E09EBC /* TypeAlias.swift */; };
 		BDE8FBF61D1BFC8D00C5A212 /* Cache.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDE8FBF51D1BFC8D00C5A212 /* Cache.framework */; };
@@ -35,6 +37,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		BD92A5A31F01089A008408AB /* ImageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageManager.swift; sourceTree = "<group>"; };
 		BDA7AE441EEA925600E09EBC /* TypeAlias.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeAlias.swift; sourceTree = "<group>"; };
 		BDE8FBE91D1BFB9F00C5A212 /* Imaginary.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Imaginary.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDE8FBF41D1BFC7C00C5A212 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -115,6 +118,7 @@
 				D2E6499A1D2109A2002F9730 /* Fetcher.swift */,
 				D2E6499F1D210A74002F9730 /* Image+Cache.swift */,
 				D59CC1371D79B23500D72C39 /* ImageDrawer.swift */,
+				BD92A5A31F01089A008408AB /* ImageManager.swift */,
 				D2E649A21D210C1A002F9730 /* ImageView+Imaginary.swift */,
 				D54225221D1D7A9300AF0046 /* NSHTTPURLResponse+Imaginary.swift */,
 				BDA7AE441EEA925600E09EBC /* TypeAlias.swift */,
@@ -380,6 +384,7 @@
 				D59CC1391D79B23500D72C39 /* ImageDrawer.swift in Sources */,
 				D2E649A81D210CDE002F9730 /* Decompressor.swift in Sources */,
 				D2E649A41D210C1A002F9730 /* ImageView+Imaginary.swift in Sources */,
+				BD92A5A51F01089A008408AB /* ImageManager.swift in Sources */,
 				D2E649B01D211067002F9730 /* Configuration+Imaginary.swift in Sources */,
 				D54225251D1D7A9600AF0046 /* Capsule.swift in Sources */,
 				D2E649AB1D210E37002F9730 /* Configuration.swift in Sources */,
@@ -407,6 +412,7 @@
 				D2E649AA1D210E37002F9730 /* Configuration.swift in Sources */,
 				D54225231D1D7A9300AF0046 /* Capsule.swift in Sources */,
 				D2E6499D1D2109A2002F9730 /* Fetcher.swift in Sources */,
+				BD92A5A41F01089A008408AB /* ImageManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Shared/Fetcher.swift
+++ b/Sources/Shared/Fetcher.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class Fetcher {
+class Fetcher: Equatable {
   enum Result {
     case success(image: Image, byteCount: Int)
     case failure(Error)
@@ -95,5 +95,12 @@ class Fetcher {
     DispatchQueue.main.async {
       closure()
     }
+  }
+
+  static func == (lhs: Fetcher, rhs: Fetcher) -> Bool {
+    return lhs.active == rhs.active &&
+      lhs.session == rhs.session &&
+      lhs.task == rhs.task &&
+      lhs.url == rhs.url
   }
 }

--- a/Sources/Shared/ImageManager.swift
+++ b/Sources/Shared/ImageManager.swift
@@ -7,7 +7,10 @@ import Foundation
 public class ImageManager {
   /// A collection of `Fetcher`'s, they will be removed from the queue as soon as they are done
   /// fetching, even if the request fails to fetch.
-  var fetchers = [Fetcher]()
+  private var fetchers = [Fetcher]()
+
+  /// Public initializer
+  public init() {}
 
   /// Fetch image from URL with completion.
   /// If the file already exists in the cache

--- a/Sources/Shared/ImageManager.swift
+++ b/Sources/Shared/ImageManager.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// `ImageManager` can be used to fetch images from a remote location. By default it will use
+/// cache and return that object if it exists, if it does not exist already if will try and fetch
+/// it from network. If it is successful it will store the image to the cache. You can opt-out of
+/// using cache by setting `useCache` to `false` when using the `fetchImage` method.
+public class ImageManager {
+  /// A collection of `Fetcher`'s, they will be removed from the queue as soon as they are done
+  /// fetching, even if the request fails to fetch.
+  var fetchers = [Fetcher]()
+
+  /// Fetch image from URL with completion.
+  /// If the file already exists in the cache
+  ///
+  /// - Parameters:
+  ///   - url: The URL of the image that should be fetched, either from network or cache (if cache is enabled).
+  ///   - useCache: Determines if the image should be fetched from cache and stored in cached after fetching.
+  ///   - completion: A completion closure that will return the image if it is successfully fetch either from cache or the network.
+  public func fetchImage(at url: URL?, useCache: Bool = true, completion: Completion?) {
+    guard let url = url else {
+      return
+    }
+
+    // If cache is disabled, it will try to fetch the image from the network.
+    guard useCache else {
+      self.fetchFromNetwork(url: url, useCache: useCache, completion: completion)
+      return
+    }
+
+    Configuration.imageCache.async.object(forKey: url.absoluteString) { [weak self] (object: Image?) in
+      guard let `self` = self else {
+        return
+      }
+
+      // Return image from cache if it exists.
+      if let image = object {
+        DispatchQueue.main.async {
+          completion?(image)
+        }
+        return
+      }
+
+      // Fetch image from URL because it does not exist in cache.
+      self.fetchFromNetwork(url: url, completion: completion)
+    }
+  }
+
+  // Cancel and remove all fetchers from `ImageManager`.
+  public func purge() {
+    fetchers.forEach { fetcher in
+      fetcher.cancel()
+      removeFetcher(fetcher)
+    }
+  }
+
+  /// Fetch image from URL
+  ///
+  /// - Parameters:
+  ///   - url: The URL of the image that should be fetch from the network.
+  ///   - completion: A completion block that gets called after the network request is done.
+  /// - Note: The completion will get `nil` back if the request fails to fetch the image.
+  fileprivate func fetchFromNetwork(url: URL, useCache: Bool = true, completion: Completion? = nil) {
+    let fetcher = Fetcher(url: url)
+    fetcher.start({ return $0 }) { [weak self] result in
+      guard let `self` = self else {
+        return
+      }
+
+      switch result {
+      case let .success(image, bytes):
+        Configuration.track?(url, nil, bytes)
+        if useCache {
+          Configuration.imageCache.async.addObject(image, forKey: url.absoluteString)
+        }
+        completion?(image)
+        self.removeFetcher(fetcher)
+      case let .failure(error):
+        Configuration.track?(url, error, 0)
+        completion?(nil)
+        self.removeFetcher(fetcher)
+      }
+    }
+
+    fetchers.append(fetcher)
+  }
+
+  /// Remove fetcher based of its index
+  ///
+  /// - Parameter fetcher: The `Fetcher` that should be removed from the queue.
+  fileprivate func removeFetcher(_ fetcher: Fetcher) {
+    guard let index = self.fetchers.index(of: fetcher) else {
+      return
+    }
+    self.fetchers.remove(at: index)
+  }
+}

--- a/Sources/Shared/ImageManager.swift
+++ b/Sources/Shared/ImageManager.swift
@@ -46,7 +46,7 @@ public class ImageManager {
   }
 
   // Cancel and remove all fetchers from `ImageManager`.
-  public func purge() {
+  public func removeFetchers() {
     fetchers.forEach { fetcher in
       fetcher.cancel()
       removeFetcher(fetcher)

--- a/Sources/Shared/ImageManager.swift
+++ b/Sources/Shared/ImageManager.swift
@@ -62,7 +62,7 @@ public class ImageManager {
   ///   - url: The URL of the image that should be fetch from the network.
   ///   - completion: A completion block that gets called after the network request is done.
   /// - Note: The completion will get `nil` back if the request fails to fetch the image.
-  fileprivate func fetchFromNetwork(url: URL, useCache: Bool = true, completion: Completion? = nil) {
+  private func fetchFromNetwork(url: URL, useCache: Bool = true, completion: Completion? = nil) {
     let fetcher = Fetcher(url: url)
     fetcher.start({ return $0 }) { [weak self] result in
       guard let `self` = self else {
@@ -90,7 +90,7 @@ public class ImageManager {
   /// Remove fetcher based of its index
   ///
   /// - Parameter fetcher: The `Fetcher` that should be removed from the queue.
-  fileprivate func removeFetcher(_ fetcher: Fetcher) {
+  private func removeFetcher(_ fetcher: Fetcher) {
     guard let index = self.fetchers.index(of: fetcher) else {
       return
     }


### PR DESCRIPTION
ImageManager can fetch images in the same way as the extension on
`ImageView`. It works pretty much in the exact same way except it does
not use any pre or post configuration closures. If the URL already
exists in the cache, that resource will be used by default, however you
can opt-out of using cache by setting `useCache` to `false` at the call
site.

`Fetcher` is now equitable, it is used to remove fetchers when they are
done doing their job in `ImageManager`.

This should not affect the current implementation of Imaginary as
`ImageManager` is completely separate from the image view extensions
that we had (and still have).