### PR TITLE
Improve macOS implementation and minor improvement to the shared components.

### DIFF
--- a/Sources/Mac/Extensions/Configuration+Imaginary.swift
+++ b/Sources/Mac/Extensions/Configuration+Imaginary.swift
@@ -7,7 +7,7 @@ public extension Configuration {
   }
 
   public static var transitionClosure: ((NSImageView, NSImage) -> Void) = { imageView, newImage in
-    guard let oldImage = imageView.image else {
+    guard let oldImage = imageView.image, imageView.window?.inLiveResize == false else {
       imageView.image = newImage
       return
     }

--- a/Sources/Mac/Extensions/Configuration+Imaginary.swift
+++ b/Sources/Mac/Extensions/Configuration+Imaginary.swift
@@ -16,6 +16,7 @@ public extension Configuration {
     animation.duration = 0.25
     animation.fromValue = oldImage.cgImage
     animation.toValue = newImage.cgImage
+    imageView.wantsLayer = true
     imageView.layer?.add(animation, forKey: "transitionAnimation")
     imageView.image = newImage
   }
@@ -24,6 +25,7 @@ public extension Configuration {
     let animation = CABasicAnimation(keyPath: "opacity")
     animation.fromValue = imageView.layer?.opacity
     animation.toValue = 1.0
+    imageView.wantsLayer = true
     imageView.layer?.add(animation, forKey: "fadeAnimation")
     imageView.layer?.opacity = 1.0
   }

--- a/Sources/Shared/ImageView+Imaginary.swift
+++ b/Sources/Shared/ImageView+Imaginary.swift
@@ -23,7 +23,7 @@ extension ImageView {
 
       if let image = object {
         DispatchQueue.main.async {
-          self.image = image
+          Configuration.transitionClosure(self, image)
           completion?(image)
         }
 


### PR DESCRIPTION
**Set `wantsLayer` to true before trying to add an animation**

On macOS, layers are optional, so with the current implementation we
assume that it is always there which is a wrong assumption. To fix this
issue, we now set `wantsLayer` to `true` before adding the animation.

```
Setting the value of this property to true turns the view into a
layer-backed view—that is, the view uses a CALayer object to manage its
rendered content. Creating a layer-backed view implicitly causes the
entire view hierarchy under that view to become layer-backed. Thus, the
view and all of its subviews (including subviews of subviews) become
layer-backed. The default value of this property is false.
```

**Use transition closure instead of setting the image**
Setting the image again can cause the view to blink as it will render
the image on screen because the layer needs updating. By piggy backing
on `transitionClosure`, it will animate from one image to another, but
only if the old image exists. If the image view has no image, it will
simply assign the image to self as the previous implementation did.

**Opt-out from setting the image again if the window is resizing.**