### PR TITLE
Customise cache and downloader

### DIFF
--- a/Example/ImaginaryDemo/Podfile.lock
+++ b/Example/ImaginaryDemo/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Cache (4.0.0):
     - SwiftHash (~> 2.0.0)
-  - Imaginary (3.0.0):
+  - Imaginary (3.0.2):
     - Cache (~> 4.0)
   - SwiftHash (2.0.0)
 
@@ -14,7 +14,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Cache: e73353960c614ab79b0c6911b8c39da05b334470
-  Imaginary: 61c53e76b1b6f84cb86e98b0b8d47b535af89204
+  Imaginary: ef0a73d0d09a1191f9e6763d6d4b6424176a6b4e
   SwiftHash: d2e09b13495447178cdfb8e46e54a5c46f15f5a9
 
 PODFILE CHECKSUM: 317cccf04e61f3f6f7e8a7e2dbc1ad0f7fa2beee

--- a/ImaginaryTests-iOS/Button+ImaginaryTests.swift
+++ b/ImaginaryTests-iOS/Button+ImaginaryTests.swift
@@ -9,12 +9,16 @@ private final class Button_ImaginaryTests: XCTestCase {
     let button = UIButton()
     let placeholder = TestHelper.image(.green,
                                        size: CGSize(width: 50, height: 50))
-    let mockDownloader = MockDownloader()
+    let mockDownloader = MockDownloader(modifyRequest: { $0 })
 
     // Mock the Fetcher
     var option = Option(imageDisplayer: ButtonDisplayer())
-    option.fetcherMaker = {
-      return ImageFetcher(downloader: mockDownloader, storage: nil)
+    option.downloaderMaker = {
+      return mockDownloader
+    }
+
+    option.storageMaker = {
+      return nil
     }
 
     button.setImage(

--- a/ImaginaryTests-iOS/ImageFetcherTests.swift
+++ b/ImaginaryTests-iOS/ImageFetcherTests.swift
@@ -5,7 +5,7 @@ import Cache
 private final class ImageFetcherTests: XCTestCase {
   var storage: Storage!
   var fetcher: ImageFetcher!
-  fileprivate var mockDownloader = MockDownloader()
+  fileprivate var mockDownloader = MockDownloader(modifyRequest: { $0 })
   let url = URL(string: "https://no.hyper/imaginary.png")!
 
   override func setUp() {

--- a/ImaginaryTests-iOS/ImageView+ImaginaryTests.swift
+++ b/ImaginaryTests-iOS/ImageView+ImaginaryTests.swift
@@ -9,12 +9,16 @@ private final class ImageView_ImaginaryTests: XCTestCase {
     let imageView = UIImageView()
     let placeholder = TestHelper.image(.green,
                                        size: CGSize(width: 50, height: 50))
-    let mockDownloader = MockDownloader()
+    let mockDownloader = MockDownloader(modifyRequest: { $0 })
 
     // Mock the Fetcher
     var option = Option()
-    option.fetcherMaker = {
-      return ImageFetcher(downloader: mockDownloader, storage: nil)
+    option.downloaderMaker = {
+      return mockDownloader
+    }
+
+    option.storageMaker = {
+      return nil
     }
 
     imageView.setImage(

--- a/ImaginaryTests-iOS/MultipleImageFetcherTests.swift
+++ b/ImaginaryTests-iOS/MultipleImageFetcherTests.swift
@@ -27,7 +27,7 @@ private final class MultipleImageFetcherTests: XCTestCase {
     ]
 
     let multipleFetcher = MultipleImageFetcher(fetcherMaker: {
-      return ImageFetcher(downloader: MockDownloader(), storage: self.storage)
+      return ImageFetcher(downloader: MockDownloader(modifyRequest: { $0 }), storage: self.storage)
     })
 
     multipleFetcher.fetch(urls: urls, each: { result in

--- a/README.md
+++ b/README.md
@@ -140,21 +140,38 @@ These are the buit in displayers. You need to supply the correct displayer for y
 - [x] ButtonDisplayer: display onto `UI|NSButton` using `setImage(_ image: UIImage?, for state: UIControlState)`
 - [x] ButtonBackgroundDisplayer: display onto `UI|NSButton` using `setBackgroundImage(_ image: UIImage?, for state: UIControlState)`
 
-### Fetching
+### Downloading
 
-`Imaginary` uses `ImageFetcher` under the hood. You can use your own fetcher and storage. The storage defaults to `Configuration.storage`, but you can use your own `Storage`, this allows your to group images for a particular feature.
+`Imaginary` uses `ImageFetcher` under the hood, which has downloader and storage.  You can specify your own `ImageDownloader` together with a `modifyRequest` closure, there you can change request body or add more HTTP headers.
 
-What if you want forced downloading and ignore storage? Then just pass `nil` to `storage`. This is how you can customise via `fetcherMaker`
 
 ```swift
 var option = Option()
-option.fetcherMaker = {
-  return ImageFetcher(downloader: ImageDownloader(), storage: nil)
+option.downloaderMaker = {
+  return ImageDownloader(modifyRequest: { 
+    var request = $0
+    request.addValue("Bearer 123", forHTTPHeaderField: "Authorization")
+    return request 
+  })
 }
+
 imageView.setImage(imageUrl, option: option)
 ```
 
-For how to configure `storage`, see [Storage](https://github.com/hyperoslo/Cache#storage)
+
+### Caching
+
+
+
+The storage defaults to `Configuration.storage`, but you can use your own `Storage`, this allows you to group saved images for particular feature. What if you want forced downloading and ignore storage? Then simply return `nil`. For how to configure `storage`, see [Storage](https://github.com/hyperoslo/Cache#storage)
+
+```swift
+var option = Option()
+option.storageMaker = {
+  return Configuration.storage
+}
+```
+
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ These are the buit in displayers. You need to supply the correct displayer for y
 
 `Imaginary` uses `ImageFetcher` under the hood, which has downloader and storage.  You can specify your own `ImageDownloader` together with a `modifyRequest` closure, there you can change request body or add more HTTP headers.
 
-
 ```swift
 var option = Option()
 option.downloaderMaker = {
@@ -158,10 +157,7 @@ option.downloaderMaker = {
 imageView.setImage(imageUrl, option: option)
 ```
 
-
 ### Caching
-
-
 
 The storage defaults to `Configuration.storage`, but you can use your own `Storage`, this allows you to group saved images for particular feature. What if you want forced downloading and ignore storage? Then simply return `nil`. For how to configure `storage`, see [Storage](https://github.com/hyperoslo/Cache#storage)
 
@@ -171,7 +167,6 @@ option.storageMaker = {
   return Configuration.storage
 }
 ```
-
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The storage defaults to `Configuration.storage`, but you can use your own `Stora
 ```swift
 var option = Option()
 option.storageMaker = {
-  return Configuration.storage
+  return Configuration.imageStorage
 }
 ```
 

--- a/Sources/Shared/Extensions/View+Imaginary.swift
+++ b/Sources/Shared/Extensions/View+Imaginary.swift
@@ -19,7 +19,11 @@ extension View {
 
     cancelImageFetch()
 
-    self.imageFetcher = option.fetcherMaker()
+    self.imageFetcher = ImageFetcher(
+      downloader: ImageDownloader(modifyRequest: option.modifyRequest),
+      storage: option.storageMaker()
+    )
+
     self.imageFetcher?.fetch(url: url, completion: { [weak self] result in
       guard let `self` = self else {
         return

--- a/Sources/Shared/Extensions/View+Imaginary.swift
+++ b/Sources/Shared/Extensions/View+Imaginary.swift
@@ -20,7 +20,7 @@ extension View {
     cancelImageFetch()
 
     self.imageFetcher = ImageFetcher(
-      downloader: ImageDownloader(modifyRequest: option.modifyRequest),
+      downloader: option.downloaderMaker(),
       storage: option.storageMaker()
     )
 

--- a/Sources/Shared/Fetcher/ImageDownloader.swift
+++ b/Sources/Shared/Fetcher/ImageDownloader.swift
@@ -3,14 +3,19 @@ import Foundation
 /// Download image from url
 public class ImageDownloader {
   fileprivate let session: URLSession
+  fileprivate let modifyRequest: (URLRequest) -> (URLRequest)
 
   fileprivate var task: URLSessionDataTask?
   fileprivate var active = false
 
   // MARK: - Initialization
 
-  public init(session: URLSession = URLSession.shared) {
+  public init(
+    session: URLSession = URLSession.shared,
+    modifyRequest: @escaping (URLRequest) -> (URLRequest)) {
+
     self.session = session
+    self.modifyRequest = modifyRequest
   }
 
   // MARK: - Operation
@@ -18,7 +23,8 @@ public class ImageDownloader {
   public func download(url: URL, completion: @escaping (Result) -> Void) {
     active = true
 
-    self.task = self.session.dataTask(with: url,
+    var request = modifyRequest(URLRequest(url: url))
+    self.task = self.session.dataTask(with: request,
                                       completionHandler: { [weak self] data, response, error in
       guard let `self` = self, self.active else {
         return

--- a/Sources/Shared/Fetcher/ImageDownloader.swift
+++ b/Sources/Shared/Fetcher/ImageDownloader.swift
@@ -23,7 +23,7 @@ public class ImageDownloader {
   public func download(url: URL, completion: @escaping (Result) -> Void) {
     active = true
 
-    var request = modifyRequest(URLRequest(url: url))
+    let request = modifyRequest(URLRequest(url: url))
     self.task = self.session.dataTask(with: request,
                                       completionHandler: { [weak self] data, response, error in
       guard let `self` = self, self.active else {

--- a/Sources/Shared/Fetcher/ImageFetcher.swift
+++ b/Sources/Shared/Fetcher/ImageFetcher.swift
@@ -12,8 +12,7 @@ public class ImageFetcher {
   /// - Parameters:
   ///   - downloader: Used to download images.
   ///   - storage: Used to store downloaded images. Pass nil to ignore cache
-  public init(downloader: ImageDownloader = ImageDownloader(),
-              storage: Storage? = Configuration.imageStorage) {
+  public init(downloader: ImageDownloader, storage: Storage?) {
     self.downloader = downloader
     self.storage = storage
   }

--- a/Sources/Shared/Library/Option.swift
+++ b/Sources/Shared/Library/Option.swift
@@ -17,11 +17,9 @@ public struct Option {
     return Configuration.imageStorage
   }
 
-  /// Modify request before it is sent
-  public var modifyRequest: (URLRequest) -> URLRequest = {
-    var request = $0
-    request.httpMethod = "GET"
-    return request
+  /// Specify ImageDownloader and request modifier
+  public var downloaderMaker: () -> ImageDownloader = {
+    return ImageDownloader(modifyRequest: { $0 })
   }
 
   public init(imagePreprocessor: ImageProcessor? = nil,

--- a/Sources/Shared/Library/Option.swift
+++ b/Sources/Shared/Library/Option.swift
@@ -10,11 +10,18 @@ public struct Option {
   /// To apply transition or custom animation when display image
   public let imageDisplayer: ImageDisplayer
 
-  /// How to make ImageFetcher to fetch.
-  /// Defaults to ImageFetcher with Configuration.imageStorage, specify nil to ignore caching.
-  public var fetcherMaker: () -> ImageFetcher = {
-    return ImageFetcher(downloader: ImageDownloader(),
-                        storage: Configuration.imageStorage)
+  /// Specify Storage for memory and disk cache.
+  /// Defaults to Configuration.imageStorage.
+  /// Return nil to ignore cache
+  public var storageMaker: () -> Storage? = {
+    return Configuration.imageStorage
+  }
+
+  /// Modify request before it is sent
+  public var modifyRequest: (URLRequest) -> URLRequest = {
+    var request = $0
+    request.httpMethod = "GET"
+    return request
   }
 
   public init(imagePreprocessor: ImageProcessor? = nil,


### PR DESCRIPTION
- This tries to fix https://github.com/hyperoslo/Imaginary/issues/74
- Allow customising Storage
- Allow customising ImageDownloader together with a `modify request` closure

We get some logs

```
2018-01-02 12:53:31.080357+0100 ImaginaryDemo[90905:733957] Task <A4C7C3D2-0730-4E37-93D5-8FC7A93DC219>.<3> finished with error - code: -999
2018-01-02 12:53:31.130806+0100 ImaginaryDemo[90905:733943] Task <4BCA1ED2-223E-489D-94A6-E0894D0B3D4C>.<1> finished with error - code: -999
```

This is because of excessive logging in iOS 11 https://forums.developer.apple.com/thread/88336