### PR TITLE
Use tag instead of branch for cache

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["Imaginary"]),
     ],
     dependencies: [
-      .package(url: "https://github.com/hyperoslo/Cache", .branch("master"))
+        .package(url: "https://github.com/hyperoslo/Cache", .exactItem("5.0.0"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
Use tag instead of branch for cache

Since SPM is complaining about unstable-package dependency while using branch `master`.

So, used `tag` instead.